### PR TITLE
format list_user_orders query

### DIFF
--- a/flower_bot.py
+++ b/flower_bot.py
@@ -203,7 +203,9 @@ async def list_user_orders(user_id: int) -> list[dict]:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         cur = await db.execute(
-            "SELECT o.id,o.status,o.total_u,o.created_at,b.title,b.size,b.number FROM orders o JOIN bouquets b ON b.id=o.bouquet_id WHERE o.user_id=? ORDER BY o.created_at DESC",
+            "SELECT o.id, o.status, o.total_u, o.created_at, b.title, b.size, b.number "
+            "FROM orders o JOIN bouquets b ON b.id = o.bouquet_id "
+            "WHERE o.user_id=? ORDER BY o.created_at DESC",
             (user_id,),
         )
         rows = await cur.fetchall()


### PR DESCRIPTION
## Summary
- format list_user_orders SQL query using concatenated strings for readability

## Testing
- `python -m py_compile flower_bot.py`
- `python - <<'PY'
import asyncio
from flower_bot import list_user_orders
async def main():
    res = await list_user_orders(1)
    print(type(res), len(res))
    if res:
        print(res[0])
asyncio.run(main())
PY` *(fails: sqlite3.OperationalError: no such column: o.total_u)*

------
https://chatgpt.com/codex/tasks/task_e_68a599336ff4832382691702dda9fc87