### PR TITLE
docs: fix run command in header

### DIFF
--- a/flower_bot.py
+++ b/flower_bot.py
@@ -1,7 +1,7 @@
 # bot.py
 # Minimal Telegram flower shop bot (aiogram v3.13)
 # Sends album of bouquets (no captions) + separate numbered list with prices.
-# Run: python3 bot.py
+# Run: python3 flower_bot.py
 
 import asyncio
 import logging


### PR DESCRIPTION
## Summary
- correct run command to reference `flower_bot.py`

## Testing
- `python -m py_compile flower_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5b78bdaf08323a18b80c641cd7e29