### PR TITLE
Reset state after duplicate bouquet addition

### DIFF
--- a/flower_bot.py
+++ b/flower_bot.py
@@ -497,9 +497,12 @@ async def admin_add_photo(m: Message, state: FSMContext):
             )
             await db.commit()
         except aiosqlite.IntegrityError:
-            return await m.answer(
-                "Bouquet with this number already exists in this size."
+            await m.answer(
+                "Bouquet with this number already exists in this size.",
+                reply_markup=main_menu(),
             )
+            await state.clear()
+            return
     await m.answer("Added!", reply_markup=main_menu())
     await state.clear()
 


### PR DESCRIPTION
## Summary
- reset admin add photo FSM state when bouquet number already exists
- present main menu on duplicate number error

## Testing
- `python -m py_compile flower_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5bb5ab10483239d345b7fe02c4480